### PR TITLE
feat: allow agent pool token to be provided via an existing secret

### DIFF
--- a/charts/agent-k8s/Chart.yaml
+++ b/charts/agent-k8s/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   > It has many advantages over the [`agent-docker`](/charts/agent-docker) chart and
   > would eventually replace it.
 type: application
-version: 0.2.5
+version: "0.3.0"
 appVersion: "0.5.0"
 home: https://github.com/Scalr/agent-helm/tree/master/charts/agent-k8s
 maintainers:

--- a/charts/agent-k8s/templates/controller.yaml
+++ b/charts/agent-k8s/templates/controller.yaml
@@ -15,7 +15,9 @@ spec:
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if not .Values.agent.tokenExistingSecret }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+      {{- end }}
       labels:
         {{- include "agent-k8s.selectorLabels" . | nindent 8 }}
     spec:
@@ -34,7 +36,7 @@ spec:
             - name: SCALR_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "agent-k8s.name" . }}
+                  name: {{ .Values.agent.tokenExistingSecret | default (include "agent-k8s.name" .) }}
                   key: token
                   optional: false
             - name: SCALR_AGENT_NAME

--- a/charts/agent-k8s/templates/secrets.yaml
+++ b/charts/agent-k8s/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.agent.tokenExistingSecret }}
 apiVersion: v1
 data:
   token: {{ required ".Values.agent.token must be provided!" .Values.agent.token | b64enc }}
@@ -12,3 +13,4 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: Opaque
+{{- end }}

--- a/charts/agent-k8s/values.yaml
+++ b/charts/agent-k8s/values.yaml
@@ -13,6 +13,8 @@ agent:
   url: ""
   # -- The agent pool token.
   token: ""
+  # -- The name of the secret containing the agent pool token. Secret is created if left empty.
+  tokenExistingSecret: ""
   # -- Enable debug logs
   debug: false
   # -- The log formatter. Options: "plain" or "dev" or "json".


### PR DESCRIPTION
Hello,

Thanks for setting up this chart, that's very helpful.

I would like to suggest the following improvement: a lot of people rely on an external controller (e.g. External Secrets Operator) to sync Kubernetes secrets, for security and scalability reasons.
This PR is about adding the option to specify an existing secret containing the Scalr token. If it is not set (as per default), then it is created using the inline token value (the current behavior).

Kr,
Fred