### PR TITLE
Change data_home default to avoid Flexvolume plugin conflict in GKE

### DIFF
--- a/charts/agent-k8s/values.yaml
+++ b/charts/agent-k8s/values.yaml
@@ -28,7 +28,7 @@ agent:
   # -- Determines if the agent should automatically disconnect from the Scalr agent pool when the service is stopping.
   disconnect_on_stop: true
   # -- The agent working directory on the cluster host node.
-  data_home: "/home/scalr/agent-k8s"
+  data_home: "/home/kubernetes/bin/scalr/agent-k8s"
   # -- The container task's (e.g., Kubernetes Pod) scheduling timeout in seconds.
   # The task will be waiting for the scheduling in the queued status; if the cluster
   # does not allocate resources for the container in that timeout, the task will be switched to the errored status.

--- a/charts/agent-k8s/values.yaml
+++ b/charts/agent-k8s/values.yaml
@@ -28,7 +28,7 @@ agent:
   # -- Determines if the agent should automatically disconnect from the Scalr agent pool when the service is stopping.
   disconnect_on_stop: true
   # -- The agent working directory on the cluster host node.
-  data_home: "/home/kubernetes/flexvolume/agent-k8s"
+  data_home: "/home/scalr/agent-k8s"
   # -- The container task's (e.g., Kubernetes Pod) scheduling timeout in seconds.
   # The task will be waiting for the scheduling in the queued status; if the cluster
   # does not allocate resources for the container in that timeout, the task will be switched to the errored status.


### PR DESCRIPTION
The Scalr agent K8s Helm chart creates a DaemonSet in the worker template that makes use of a hostPath directory. Unfortunately, the default value for this is "/home/kubernetes/flexvolume/agent-k8s", which is a directory that the GKE distribution of Kubernetes uses as its  Flexvolume plugin directory.

GKE changes the default [Flexvolume](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md) plugin directory from /var/lib/kubelet/volumeplugins to /home/kubernetes/flexvolume, in its Kubelet configuration. (Flexvolume is deprecated but still supported.) If this directory exists, Kubelet automatically scans it for new custom volume driver plugins, which causes (non-critical) errors to be constantly logged by the kubelet on every node in the cluster where this chart is installed.

This directory should be changed to something that no service running on the host should expect to be used for any other purpose. This is a simple one line change to do this, but a longer-term fix might be to move away from using a hostPath directly.