### PR TITLE
Existing token secret not used for worker daemonset

### DIFF
--- a/charts/agent-k8s/templates/worker.yaml
+++ b/charts/agent-k8s/templates/worker.yaml
@@ -34,7 +34,7 @@ spec:
             - name: SCALR_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "agent-k8s.name" . }}
+                  name: {{ .Values.agent.tokenExistingSecret | default (include "agent-k8s.name" .) }}
                   key: token
                   optional: false
             - name: SCALR_AGENT_NAME


### PR DESCRIPTION
We deploy this chart (and all others) using GitOps. As such we store the `values.yaml` in Git and because `agent.token` is a secret value, we have an issue. Thus, we're adding the secret to the cluster ourselves (in our case using the [SealedSecrets](https://github.com/bitnami-labs/sealed-secrets) operator) and utilizing the `.agent.tokenExistingSecret` value to specify the name of the existing secret containing the agent token (thank you for this feature btw!).

The chart currently has a bug where if `.agent.tokenExistingSecret` is specified, the default secret name is still used in the worker DaemonSet manifest. The controller Deployment [already handles this logic properly](https://github.com/Scalr/agent-helm/blob/aa409670e79b84b7b669879c0263f5b65994dc82/charts/agent-k8s/templates/controller.yaml#L39), so I just re-used it. This PR fixes the issue for the DaemonSet.

A workaround at the moment is to name the existing secret `agent-k8s` which is the default name the chart will use in the DaemonSet.