### PR TITLE
Pre existing secret

### DIFF
--- a/charts/agent-docker/templates/deployment.yaml
+++ b/charts/agent-docker/templates/deployment.yaml
@@ -76,8 +76,14 @@ spec:
           - name: SCALR_TOKEN
             valueFrom:
               secretKeyRef:
+              {{- if .Values.agent.tokenExistingSecret }}
+                {{- with .Values.agent.tokenExistingSecret }}
+                  {{- toYaml . | nindent 16  }}
+                {{- end }}
+              {{- else }}
                 name: {{ include "agent-docker.name" . }}
                 key: token
+              {{- end }}
                 optional: false
           livenessProbe:
             exec:

--- a/charts/agent-docker/templates/secrets.yaml
+++ b/charts/agent-docker/templates/secrets.yaml
@@ -1,6 +1,7 @@
+{{ if not .Values.agent.tokenExistingSecret }}
 apiVersion: v1
 data:
-  token: {{ required ".Values.agent.token must be provided!" .Values.agent.token | b64enc }}
+  token: {{ required ".Values.agent.token must be provided or a pre-existing secret must be specified in .Values.agent.tokenExistingSecret!" .Values.agent.token | b64enc }}
 kind: Secret
 metadata:
   name: {{ include "agent-docker.name" . }}
@@ -11,3 +12,4 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: Opaque
+{{ end }}

--- a/charts/agent-docker/values.yaml
+++ b/charts/agent-docker/values.yaml
@@ -15,6 +15,10 @@ agent:
     tag: ""
   # -- A value for agent.token must be provided for Scalr Agent authentication
   token:
+  # -- A pre-existing secret if agent.token can't be provided for Scalr Agent authentication
+  # tokenExistingSecret:
+  #  name:
+  #  key: token
   # -- A value for agent.url must be provided to specify the Scalr API endpoint
   url:
 


### PR DESCRIPTION
Allow end users to provide the secret token via a pre-created secret. This is required for users who can't specify the token using `agent.token: `.