### PR TITLE
Fix mis-named automountToken to automountServiceAccountToken

### DIFF
--- a/charts/agent-local/templates/serviceaccount.yaml
+++ b/charts/agent-local/templates/serviceaccount.yaml
@@ -13,5 +13,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken | default false }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountToken | default false }}
 {{- end }}

--- a/charts/agent-local/values.yaml
+++ b/charts/agent-local/values.yaml
@@ -81,7 +81,7 @@ serviceAccount:
   # -- Create a Kubernetes service account for the Scalr Agent.
   create: false
   # -- Whether to automount the service account token in the Scalr Agent pod.
-  automountServiceAccountToken: false
+  automountToken: false
   # -- Annotations for the service account.
   annotations: {}
   # -- Additional labels for the service account.


### PR DESCRIPTION
`automountToken` is not used.

`automountServiceAccountToken` is the actual value being used in `serviceaccount.yaml`.

I could have renamed the opposite way (i.e. renamed automountServiceAccountToken to automountToken), but it seems that in `serviceaccount.yaml`, the field names in the `spec.` are consistent with the value name, so I chose consistency.