### PR TITLE
SCALRCORE-36837: fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-app-version.yaml
+++ b/.github/workflows/update-app-version.yaml
@@ -12,6 +12,9 @@ jobs:
   update-app-version:
     name: Update appVersion
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
     steps:
       - name: Sudo GitHub Token
         id: generate_token


### PR DESCRIPTION
Potential fix for [https://github.com/Scalr/agent-helm/security/code-scanning/2](https://github.com/Scalr/agent-helm/security/code-scanning/2)

In general, to fix this issue you should add an explicit `permissions` block specifying the minimal scopes required by the job. Since this workflow updates the app version (which implies committing/pushing changes) and then dispatches another workflow, it needs `contents: write` to modify repository contents and `actions: write` to dispatch another workflow using `benc-uk/workflow-dispatch`. Other permissions can remain at their default of `none`.

The best targeted fix without changing functionality is to add a `permissions` block at the job level under `update-app-version`. This way, only this job’s `GITHUB_TOKEN` is affected, and other workflows/jobs remain unchanged. Place the block immediately under `runs-on: ubuntu-latest` to reflect that it applies to the job. The block should be:

```yaml
permissions:
  contents: write
  actions: write
```

No additional imports or external dependencies are needed; this is purely a change to the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
