### PR TITLE
SCALRCORE-37881 fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-test-chart.yaml
+++ b/.github/workflows/lint-test-chart.yaml
@@ -2,6 +2,9 @@ name: Lint and Test Charts
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   lint-test:
     if: github.repository == 'Scalr/agent-helm'


### PR DESCRIPTION
Potential fix for [https://github.com/Scalr/agent-helm/security/code-scanning/1](https://github.com/Scalr/agent-helm/security/code-scanning/1)

In general, fix this by explicitly setting a minimal `permissions` block for the workflow or for the specific job so that `GITHUB_TOKEN` has only the scopes needed (here, just read access to repository contents). For a pure lint/test workflow that only checks out code and runs tools, `contents: read` is usually sufficient.

The best fix with minimal impact is to add a root-level `permissions` block (applies to all jobs in this workflow) just under the `on:` key, setting `contents: read`. No steps in the shown job require write access to the repo, issues, or PRs, and no additional permissions (like `packages`) are clearly required from the snippet. Concretely, in `.github/workflows/lint-test-chart.yaml`, between line 3 (`on: pull_request`) and line 5 (`jobs:`), insert:

```yaml
permissions:
  contents: read
```

No imports or other definitions are needed; GitHub Actions natively supports the `permissions` key in workflows.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
