### PR TITLE
fix: agent-job labels trimming necessary newline

### DIFF
--- a/charts/agent-job/templates/_helpers.tpl
+++ b/charts/agent-job/templates/_helpers.tpl
@@ -37,7 +37,7 @@ Common labels
 helm.sh/chart: {{ include "agent-job.chart" . }}
 {{ include "agent-job.selectorLabels" . }}
 {{- with .Values.global.labels }}
-{{- toYaml . }}
+{{ toYaml . }}
 {{- end }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}


### PR DESCRIPTION
When adding global labels right now, the first label gets added to the same line as the default labels because of the trimming. Example:

`app.kubernetes.io/instance: scalr-agentmykey: myvalue`