### PR TITLE
Fix missing YAML document separator in poddisruptionbudget.yaml

### DIFF
--- a/charts/agent-job/templates/poddisruptionbudget.yaml
+++ b/charts/agent-job/templates/poddisruptionbudget.yaml
@@ -23,7 +23,7 @@ spec:
       {{- include "agent-job.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: agent
 {{- end }}
-
+---
 {{- if .Values.task.podDisruptionBudget.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget


### PR DESCRIPTION
## Description

Adds the required `---` YAML document separator between the agent and task PodDisruptionBudget resources in `charts/agent-job/templates/poddisruptionbudget.yaml`.

## Problem

When both `agent.replicaCount > 1` AND `task.podDisruptionBudget.enabled=true`, the template renders two Kubernetes PodDisruptionBudget resources without a document separator between them, producing invalid multi-resource YAML output.

This was introduced in PR #169 when the task PDB was added.

## Solution

Add `---` separator between the two conditional blocks (line 26), matching the pattern used in other multi-resource templates like `rbac.yaml` and `secrets.yaml`.

## Verification

Tested with:
```bash
helm template . --set agent.replicaCount=2 \
  --set agent.podDisruptionBudget.enabled=true \
  --set task.podDisruptionBudget.enabled=true \
  --set agent.token=test \
  --set agent.url=https://example.scalr.io
```

Output now correctly shows two separate YAML documents with `---` separator between them.